### PR TITLE
[target 1.11] Repurpose dependOslModule

### DIFF
--- a/src/main/java/net/ornithemc/ploceus/OslVersionCache.java
+++ b/src/main/java/net/ornithemc/ploceus/OslVersionCache.java
@@ -87,6 +87,10 @@ public class OslVersionCache {
 		return Collections.unmodifiableMap(modules);
 	}
 
+	public String getDependency(String version, String module) throws Exception {
+		return getDependencies(version).get(module);
+	}
+
 	/**
 	 * checks if the osl version cache contains the specified version
 	 * and queries the meta server for this data if needed

--- a/src/main/java/net/ornithemc/ploceus/PloceusGradleExtension.java
+++ b/src/main/java/net/ornithemc/ploceus/PloceusGradleExtension.java
@@ -356,23 +356,29 @@ public class PloceusGradleExtension implements PloceusGradleExtensionApi {
 	}
 
 	@Override
-	public void dependOslModule(String module, String version) throws Exception {
-		dependOslModule(module, version, GameSide.MERGED);
+	public void dependOslModule(String version, String module) throws Exception {
+		dependOslModule(version, GameSide.MERGED, module);
 	}
 
 	@Override
-	public void dependOslModule(String module, String version, String side) throws Exception {
-		dependOslModule(module, version, GameSide.of(side));
+	public void dependOslModule(String version, String side, String module) throws Exception {
+		dependOslModule(version, GameSide.of(side), module);
 	}
 
 	@Override
-	public void dependOslModule(String module, String version, GameSide side) throws Exception {
-		dependOslModule("modImplementation", module, version, side);
+	public void dependOslModule(String version, GameSide side, String module) throws Exception {
+		dependOslModule("modImplementation", version, side, module);
 	}
 
 	@Override
-	public void dependOslModule(String configuration, String module, String version, GameSide side) throws Exception {
-		addOslModuleDependency(configuration, module, oslModule(module, version, side));
+	public void dependOslModule(String configuration, String version, GameSide side, String module) throws Exception {
+		String baseVersion = oslVersions.getDependency(version, module);
+
+		if (baseVersion == null) {
+			throw new RuntimeException("osl " + version + " " + module + " for " + side.id() + " does not exist");
+		} else {
+			addOslModuleDependency(configuration, module, oslModule(module, baseVersion, side));
+		}
 	}
 
 	@Override

--- a/src/main/java/net/ornithemc/ploceus/api/PloceusGradleExtensionApi.java
+++ b/src/main/java/net/ornithemc/ploceus/api/PloceusGradleExtensionApi.java
@@ -40,13 +40,13 @@ public interface PloceusGradleExtensionApi {
 
 	void dependOsl(String configuration, String version, GameSide side) throws Exception;
 
-	void dependOslModule(String module, String version) throws Exception;
+	void dependOslModule(String version, String module) throws Exception;
 
-	void dependOslModule(String module, String version, String side) throws Exception;
+	void dependOslModule(String version, String side, String module) throws Exception;
 
-	void dependOslModule(String module, String version, GameSide side) throws Exception;
+	void dependOslModule(String version, GameSide side, String module) throws Exception;
 
-	void dependOslModule(String configuration, String module, String version, GameSide side) throws Exception;
+	void dependOslModule(String configuration, String version, GameSide side, String module) throws Exception;
 
 	String oslModule(String module, String version) throws Exception;
 


### PR DESCRIPTION
Previously it accepted a module name and base version, found the full version for the project's minecraft version, and added a dependency for that version.
Now, it accepts an OSL version and a module name, finds the module base version for the OSL version, then finds the full version for the project's minecraft version, and adds a dependency for that version.