### PR TITLE
[target 1.11] Remove realms library

### DIFF
--- a/src/main/java/net/ornithemc/ploceus/PloceusGradleExtension.java
+++ b/src/main/java/net/ornithemc/ploceus/PloceusGradleExtension.java
@@ -171,6 +171,7 @@ public class PloceusGradleExtension implements PloceusGradleExtensionApi {
 		project.getConfigurations().register(Constants.SERVER_NESTS_CONFIGURATION);
 
 		loom.getLibraryProcessors().add((platform, context) -> new LibraryUpgrader(this, platform, context));
+		loom.getLibraryProcessors().add((platform, context) -> new RealmsRemover(platform, context));
 		loom.addMinecraftJarProcessor(LvtProcessor.class, this);
 		loom.addMinecraftJarProcessor(ExceptionPatcherProcessor.class, this);
 		loom.addMinecraftJarProcessor(SignaturePatcherProcessor.class, this);

--- a/src/main/java/net/ornithemc/ploceus/RealmsRemover.java
+++ b/src/main/java/net/ornithemc/ploceus/RealmsRemover.java
@@ -1,0 +1,26 @@
+package net.ornithemc.ploceus;
+
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+
+import net.fabricmc.loom.configuration.providers.minecraft.library.Library;
+import net.fabricmc.loom.configuration.providers.minecraft.library.LibraryContext;
+import net.fabricmc.loom.configuration.providers.minecraft.library.LibraryProcessor;
+import net.fabricmc.loom.util.Platform;
+
+public class RealmsRemover extends LibraryProcessor {
+
+	public RealmsRemover(Platform platform, LibraryContext context) {
+		super(platform, context);
+	}
+
+	@Override
+	public ApplicationResult getApplicationResult() {
+		return ApplicationResult.MUST_APPLY;
+	}
+
+	@Override
+	public Predicate<Library> apply(Consumer<Library> dependencyConsumer) {
+		return lib -> !lib.is("com.mojang:realms");
+	}
+}


### PR DESCRIPTION
I tested a few versions and it seems to work just fine. The game attempts to load Realms through reflection, and if that fails, it logs the error. This has no negative side effects other than hiding the Realms notifications and making the Realms button do nothing.