### PR TITLE
clean up version directories

### DIFF
--- a/src/main/java/net/ornithemc/ploceus/exceptions/ExceptionsProvider.java
+++ b/src/main/java/net/ornithemc/ploceus/exceptions/ExceptionsProvider.java
@@ -72,10 +72,12 @@ public class ExceptionsProvider {
 		}
 
 		MinecraftProvider minecraft = loom.getMinecraftProvider();
-		Path path = minecraft.path(excsName + "-" + excsVersion + ".excs");
+		Path dir = minecraft.path("exceptions");
+		Path path = dir.resolve(excsName + "-" + excsVersion + ".excs");
 
 		if (Files.notExists(path) || minecraft.refreshDeps()) {
 			try (FileSystemUtil.Delegate delegate = FileSystemUtil.getJarFileSystem(excsJar.get().toPath())) {
+				Files.createDirectories(dir);
 				Files.copy(delegate.getPath("exceptions/mappings.excs"), path, StandardCopyOption.REPLACE_EXISTING);
 			} catch (IOException e) {
 				throw new RuntimeException("unable to extract exceptions!");

--- a/src/main/java/net/ornithemc/ploceus/nester/NestsProvider.java
+++ b/src/main/java/net/ornithemc/ploceus/nester/NestsProvider.java
@@ -70,10 +70,12 @@ public class NestsProvider {
 		}
 
 		MinecraftProvider minecraft = loom.getMinecraftProvider();
-		Path path = minecraft.path(nestsName + "-" + nestsVersion + ".nest");
+		Path dir = minecraft.path("nests");
+		Path path = dir.resolve(nestsName + "-" + nestsVersion + ".nest");
 
 		if (Files.notExists(path) || minecraft.refreshDeps()) {
 			try (FileSystemUtil.Delegate delegate = FileSystemUtil.getJarFileSystem(nestsJar.get().toPath())) {
+				Files.createDirectories(dir);
 				Files.copy(delegate.getPath("nests/mappings.nest"), path, StandardCopyOption.REPLACE_EXISTING);
 			} catch (IOException e) {
 				throw new RuntimeException("unable to extract nests!");

--- a/src/main/java/net/ornithemc/ploceus/signatures/SignaturesProvider.java
+++ b/src/main/java/net/ornithemc/ploceus/signatures/SignaturesProvider.java
@@ -73,10 +73,12 @@ public class SignaturesProvider {
 		}
 
 		MinecraftProvider minecraft = loom.getMinecraftProvider();
-		Path path = minecraft.path(sigsName + "-" + sigsVersion + ".sigs");
+		Path dir = minecraft.path("signatures");
+		Path path = dir.resolve(sigsName + "-" + sigsVersion + ".sigs");
 
 		if (Files.notExists(path) || minecraft.refreshDeps()) {
 			try (FileSystemUtil.Delegate delegate = FileSystemUtil.getJarFileSystem(sigsJar.get().toPath())) {
+				Files.createDirectories(dir);
 				Files.copy(delegate.getPath("signatures/mappings.sigs"), path, StandardCopyOption.REPLACE_EXISTING);
 			} catch (IOException e) {
 				throw new RuntimeException("unable to extract signatures!");


### PR DESCRIPTION
Ploceus adds files for Nests/Raven/Sparrow in their respective Minecraft version's directory, but if you update the build numbers several times the files can pile up. This PR changes it so these files are placed in subdirectories to keep it a bit more organized.