### PR TITLE
prioritize cache files if less than a day old

### DIFF
--- a/src/main/java/net/ornithemc/ploceus/CacheFiles.java
+++ b/src/main/java/net/ornithemc/ploceus/CacheFiles.java
@@ -1,0 +1,20 @@
+package net.ornithemc.ploceus;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.time.Instant;
+
+public class CacheFiles {
+
+	public static final Duration ONE_HOUR = Duration.ofHours(1L);
+	public static final Duration ONE_DAY = Duration.ofDays(1L);
+
+	public static boolean isStale(Path file, Duration maxAge) throws IOException {
+		Instant modifiedTime = Files.getLastModifiedTime(file).toInstant();
+		Instant minModifiedTime = Instant.now().minus(maxAge);
+
+		return modifiedTime.isBefore(minModifiedTime);
+	}
+}

--- a/src/main/java/net/ornithemc/ploceus/LibraryUpgradesCache.java
+++ b/src/main/java/net/ornithemc/ploceus/LibraryUpgradesCache.java
@@ -2,6 +2,7 @@ package net.ornithemc.ploceus;
 
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
+import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.URI;
 import java.nio.file.Files;
@@ -77,21 +78,60 @@ public class LibraryUpgradesCache {
 	private List<Library> getLibraries() {
 		List<Library> libs = null;
 
-		try {
-			libs = getLibrariesFromMeta();
-		} catch (Exception me) {
+		Exception me = null;
+		Exception ce = null;
+
+		boolean prioritizeCache = shouldPrioritizeCacheForLibraries();
+
+		if (prioritizeCache) {
 			try {
 				libs = getLibrariesFromCache();
-			} catch (Exception ce) {
-				project.getLogger().warn("unable to read library upgrades from cache for gen" + intermediaryGeneration() + " " + minecraftVersion(), ce);
-			}
-
-			if (libs == null) {
-				throw new IllegalStateException("unable to fetch library upgrades from meta for gen" + intermediaryGeneration() + " " + minecraftVersion() + ", and it is not in the cache", me);
+			} catch (Exception e) {
+				ce = e;
 			}
 		}
 
+		if (libs == null) {
+			try {
+				libs = getLibrariesFromMeta();
+			} catch (Exception e) {
+				me = e;
+			}
+		}
+
+		if (libs == null) {
+			try {
+				libs = getLibrariesFromCache();
+			} catch (Exception e) {
+				ce = e;
+			}
+		}
+
+		if (libs == null) {
+			if (ce != null) {
+				project.getLogger().warn("unable to read library upgrades from cache for gen" + intermediaryGeneration() + " " + minecraftVersion(), ce);
+			}
+
+			throw new IllegalStateException("unable to fetch library upgrades from meta for gen" + intermediaryGeneration() + " " + minecraftVersion() + ", and it is not in the cache", me);
+		}
+
 		return libs;
+	}
+
+	private boolean shouldPrioritizeCacheForLibraries() {
+		Path libsCache = librariesCache();
+
+		try {
+			return Files.exists(libsCache) && !CacheFiles.isStale(libsCache, CacheFiles.ONE_DAY);
+		} catch (IOException e) {
+			try {
+				Files.deleteIfExists(libsCache);
+			} catch (IOException de) {
+				throw new IllegalStateException("unable to delete corrupt cache file", e);
+			}
+
+			return false;
+		}
 	}
 
 	private List<Library> getLibrariesFromMeta() throws Exception {

--- a/src/main/java/net/ornithemc/ploceus/OslVersionCache.java
+++ b/src/main/java/net/ornithemc/ploceus/OslVersionCache.java
@@ -2,6 +2,7 @@ package net.ornithemc.ploceus;
 
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
+import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.URI;
 import java.nio.file.Files;
@@ -101,21 +102,60 @@ public class OslVersionCache {
 	private Map<String, String> getModuleBaseVersions(String version) {
 		Map<String, String> baseVersions = null;
 
-		try {
-			baseVersions = getModuleBaseVersionsFromMeta(version);
-		} catch (Exception me) {
+		Exception me = null;
+		Exception ce = null;
+
+		boolean prioritizeCache = shouldPrioritizeCacheForModuleBaseVersions();
+
+		if (prioritizeCache) {
 			try {
 				baseVersions = getModuleBaseVersionsFromCache(version);
-			} catch (Exception ce) {
-				project.getLogger().warn("unable to read OSL module base versions from cache for gen" + intermediaryGeneration() + " " + version, ce);
-			}
-
-			if (baseVersions == null) {
-				throw new IllegalStateException("unable to fetch OSL module base versions from meta for gen" + intermediaryGeneration() + " " + version + ", and it is not in the cache", me);
+			} catch (Exception e) {
+				ce = e;
 			}
 		}
 
+		if (baseVersions == null) {
+			try {
+				baseVersions = getModuleBaseVersionsFromMeta(version);
+			} catch (Exception e) {
+				me = e;
+			}
+		}
+
+		if (baseVersions == null) {
+			try {
+				baseVersions = getModuleBaseVersionsFromCache(version);
+			} catch (Exception e) {
+				ce = e;
+			}
+		}
+
+		if (baseVersions == null) {
+			if (ce != null) {
+				project.getLogger().warn("unable to read OSL module base versions from cache for gen" + intermediaryGeneration() + " " + version, ce);
+			}
+
+			throw new IllegalStateException("unable to fetch OSL module base versions from meta for gen" + intermediaryGeneration() + " " + version + ", and it is not in the cache", me);
+		}
+
 		return baseVersions;
+	}
+
+	private boolean shouldPrioritizeCacheForModuleBaseVersions() {
+		Path baseVersionsCache = moduleBaseVersionsCache();
+
+		try {
+			return Files.exists(baseVersionsCache) && !CacheFiles.isStale(baseVersionsCache, CacheFiles.ONE_DAY);
+		} catch (IOException e) {
+			try {
+				Files.deleteIfExists(baseVersionsCache);
+			} catch (IOException de) {
+				throw new IllegalStateException("unable to delete corrupt cache file", e);
+			}
+
+			return false;
+		}
 	}
 
 	private Map<String, String> getModuleBaseVersionsFromMeta(String version) throws Exception {
@@ -237,21 +277,60 @@ public class OslVersionCache {
 	private String getModuleVersion(String module, String version, GameSide side) {
 		String moduleVersion = null;
 
-		try {
-			moduleVersion = getModuleVersionFromMeta(module, version, side);
-		} catch (Exception me) {
+		Exception me = null;
+		Exception ce = null;
+
+		boolean prioritizeCache = shouldPrioritizeCacheForModuleVersions();
+
+		if (prioritizeCache) {
 			try {
 				moduleVersion = getModuleVersionFromCache(module, version, side);
-			} catch (Exception ce) {
-				project.getLogger().warn("unable to read OSL module version from cache for gen" + intermediaryGeneration() + " " + module + " " + version, ce);
-			}
-
-			if (moduleVersion == null) {
-				throw new IllegalStateException("unable to fetch OSL module version from meta for gen" + intermediaryGeneration() + " " + module + " " + version + ", and it is not in the cache", me);
+			} catch (Exception e) {
+				ce = e;
 			}
 		}
 
+		if (moduleVersion == null) {
+			try {
+				moduleVersion = getModuleVersionFromMeta(module, version, side);
+			} catch (Exception e) {
+				me = e;
+			}
+		}
+
+		if (moduleVersion == null) {
+			try {
+				moduleVersion = getModuleVersionFromCache(module, version, side);
+			} catch (Exception e) {
+				ce = e;
+			}
+		}
+
+		if (moduleVersion == null) {
+			if (ce != null) {
+				project.getLogger().warn("unable to read OSL module version from cache for gen" + intermediaryGeneration() + " " + version, ce);
+			}
+
+			throw new IllegalStateException("unable to fetch OSL module version from meta for gen" + intermediaryGeneration() + " " + version + ", and it is not in the cache", me);
+		}
+
 		return moduleVersion;
+	}
+
+	private boolean shouldPrioritizeCacheForModuleVersions() {
+		Path versionsCache = moduleVersionsCache();
+
+		try {
+			return Files.exists(versionsCache) && !CacheFiles.isStale(versionsCache, CacheFiles.ONE_DAY);
+		} catch (IOException e) {
+			try {
+				Files.deleteIfExists(versionsCache);
+			} catch (IOException de) {
+				throw new IllegalStateException("unable to delete corrupt cache file", e);
+			}
+
+			return false;
+		}
 	}
 
 	private String getModuleVersionFromMeta(String module, String version, GameSide side) throws Exception {


### PR DESCRIPTION
closes #18 

This applies to both the library upgrades and OSL versions. The download logic is now as follows:
- if the cache file exists and is less than a day old, attempt to parse the desired information from it
- if that fails, or the cache file does not exist, or it is stale, then query the meta
- if that fails, attempt to parse the desired information from the cache file